### PR TITLE
Add prod and dev environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,4 @@ RUN useradd --user-group --system --create-home --no-log-init spring
 USER spring
 ARG JAR_FILE=build/libs/*
 COPY ${JAR_FILE} io-rpg.jar
-CMD java -Djava.security.egd=file:/dev/./urandom -Dserver.port=$PORT -jar /io-rpg.jar
+CMD java -Dspring.profiles.active=prod -Djava.security.egd=file:/dev/./urandom -Dserver.port=$PORT -jar /io-rpg.jar

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,1 @@
+spring.jpa.hibernate.ddl-auto=create-drop

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -1,0 +1,2 @@
+spring.jpa.hibernate.ddl-auto=update
+debug=false

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,3 @@
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.PostgreSQLDialect
-spring.jpa.hibernate.ddl-auto=update
+spring.application.name=cuteanimals
+spring.active.profiles=prod


### PR DESCRIPTION
From now on, default environment is set to `prod`. One should set environment variable `SPRING_PROFILES_ACTIVE` to `dev` or use `-Dspring.profiles.active=dev` flag to have development environment.

Close #80